### PR TITLE
Fixes credentials on Fargate stream-rtsp-to-kvs.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 **/node_modules/
+cdk.out/
+.env
+
+package-lock.json
+fargate-cdk-app/index.js

--- a/fargate-cdk-app/README.md
+++ b/fargate-cdk-app/README.md
@@ -5,6 +5,7 @@ This example will create:
 - A new VPC with an Internet Gateway
 - Public and Private subnets
 - A security group with egress traffic only
+- An IAM Role for the ECS Task
 - An ECS/Fargate Cluster, Task, and Task Definition
 
 ## Pre-requisites
@@ -30,15 +31,19 @@ $ npm install
 $ npm run build
 $ cdk bootstrap
 ```
-### Set the valus in stream-rtsp-to-kvs.sh
-Set the RTSP_URL value in <a href="https://github.com/aws-samples/cloud-gateway-for-amazon-kinesis-video-streams/blob/main/ec2-cdk-app/src/stream-rtsp-to-kvs.sh">stream-rtsp-to-kvs.sh</a>.  If you have used a different STEAM_NAME in <a href="https://github.com/aws-samples/cloud-gateway-for-amazon-kinesis-video-streams/blob/main/README.md#step-1-create-a-kinesis-video-stream">STEP 1: Create Kinesis Video Stream</a>, update STREAM_NAME to match.
-1. STREAM_NAME=CloudGatewayStream
-2. RTSP_URL="rtsp://kvsedge:stream1234@your-ip-cam:554/"
+### Use deployment context variables to customize your Stream Name and RTSP URL
 
-Deploy with the CDK.
+You can use CDK's context variables to pass the name of the Stream you created 
+previously and the url or your RTSP stream.
 
 ```bash
-$ cdk deploy 
+$ cdk deploy --context streamName=<YourStreamName> --context rtspUrl=<YourRtspUrl>
+```
+
+For example:
+
+```bash
+$ cdk deploy --context streamName=CloudGatewayStream --context rtspUrl=rtsp://kvsedge:stream1234@your-ip-cam:554/
 ```
 
 ## To Destroy

--- a/fargate-cdk-app/index.ts
+++ b/fargate-cdk-app/index.ts
@@ -1,11 +1,15 @@
 import ec2 = require('aws-cdk-lib/aws-ec2');
 import ecs = require('aws-cdk-lib/aws-ecs');
+import iam = require('aws-cdk-lib/aws-iam');
 import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
 import cdk = require('aws-cdk-lib');
 import path = require('path');
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'FargateServiceWithLocalImage');
+
+const streamName = app.node.tryGetContext('streamName') || 'CloudGatewayStream'
+const rtspUrl = app.node.tryGetContext('rtspUrl') || 'rtsp://kvsedge:stream1234@your-ip-cam:554/'
 
 // Create VPC and Fargate Cluster
 // NOTE: Limit AZs to avoid reaching resource quotas
@@ -31,6 +35,23 @@ const vpc = new ec2.Vpc(stack, 'MyVpc', {
 //const igwId = vpc.internetGatewayId;
 const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
 
+const taskRole = new iam.Role(stack, 'taskRole', {
+  assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'), roleName: 'kvsCloudGatewayInstanceRole'
+});
+
+taskRole.addToPolicy(new iam.PolicyStatement({
+  effect: iam.Effect.ALLOW,
+  actions: [
+    'kinesisvideo:CreateStream',
+    'kinesisvideo:DescribeStream',
+    'kinesisvideo:GetDataEndpoint',
+    'kinesisvideo:PutMedia',
+  ],
+  resources: [
+    `arn:aws:kinesisvideo:${cdk.Stack.of(stack).region}:${cdk.Stack.of(stack).account}:stream/${streamName}/*`
+  ]
+}));
+
 // Instantiate Fargate Service with a cluster and a local image that gets
 // uploaded to an S3 staging bucket prior to being uploaded to ECR.
 // A new repository is created in ECR and the Fargate service is created
@@ -40,7 +61,12 @@ new ecs_patterns.ApplicationLoadBalancedFargateService(stack, "FargateService", 
    memoryLimitMiB: 4096,
   cpu: 2048,
   taskImageOptions: {
-    image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'local-image'))
+    image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'local-image')),
+    taskRole: taskRole,
+    environment: {
+      STREAM_NAME: streamName,
+      RTSP_URL: rtspUrl,
+    }
   },
 });
 

--- a/fargate-cdk-app/local-image/Dockerfile
+++ b/fargate-cdk-app/local-image/Dockerfile
@@ -1,7 +1,8 @@
 # Build docker with
 # docker build -t kinesis-video-producer-sdk-cpp-amazon-linux .
 #
-FROM ubuntu:22.04
+ARG BUILDPLATFORM="linux/amd64"
+FROM --platform=${BUILDPLATFORM} ubuntu:22.04
 #apt-get install tzdata noninteractive. Without the next line, one will be prompted during build to select timezone.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
 RUN apt-get install -y \
@@ -25,6 +26,7 @@ RUN apt-get install -y \
         curl \
         diffutils \
         flex \
+        jq \
         make
 
 ENV KVS_SDK_VERSION v3.2.0

--- a/fargate-cdk-app/local-image/stream-rtsp-to-kvs.sh
+++ b/fargate-cdk-app/local-image/stream-rtsp-to-kvs.sh
@@ -1,8 +1,50 @@
 #!/bin/bash
 
-TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
-PAYLOAD=`curl -s -H "X-aws-ec2-metadata-token: $TOKEN" curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/kvsCloudGatewayInstanceRole`
+# Check if ECS container credentials are available (Fargate/ECS specific endpoint)
+# ECS containers have a special endpoint for credentials
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
+# https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
+TASK_ROLE_NAME=${TASK_ROLE_NAME:-kvsCloudGatewayInstanceRole}
+ECS_CONTAINER_METADATA_URI_V4=${ECS_CONTAINER_METADATA_URI_V4:-"http://169.254.170.2"}
 
+if [ -n "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" ]; then
+  echo "Using ECS task IAM role credentials endpoint"
+  PAYLOAD=`curl --connect-timeout 2 --max-time 5 -s "${ECS_CONTAINER_METADATA_URI_V4}${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}"`
+else
+  echo "Requesting IMDSv2 token..."
+  TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+
+  if [ -z "$TOKEN" ]; then
+    echo "ERROR: Failed to obtain IMDSv2 token (empty response)"
+    exit 1
+  else
+    echo "Token received (first 5 chars): ${TOKEN:0:5}..."
+  fi
+
+  echo "Requesting credentials for role $TASK_ROLE_NAME..."  
+  PAYLOAD=`curl -s -H "X-aws-ec2-metadata-token: $TOKEN" curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/$TASK_ROLE_NAME`
+fi
+
+if [ -z "$PAYLOAD" ]; then
+  echo "ERROR: Empty response from metadata service"
+    
+  # Show available roles for troubleshooting
+  echo "Checking available roles..."
+  AVAILABLE_ROLES=`curl --connect-timeout 2 --max-time 5 -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/`
+  echo "Available roles: $AVAILABLE_ROLES"
+  
+  echo "All credential retrieval methods failed. Attempting to proceed with AWS SDK default credential provider chain."
+  echo "Setting AWS_SDK_LOAD_CONFIG=1 to ensure SDK checks all credential sources"
+  export AWS_SDK_LOAD_CONFIG=1
+  
+  # Set default region if not already set
+  export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-"us-east-1"}
+  echo "Using AWS region: $AWS_DEFAULT_REGION"
+  
+  # Continue execution and let the AWS SDK handle credentials
+  echo "Proceeding with AWS SDK credential provider chain"
+fi
+  
 export AWS_ACCESS_KEY_ID=`echo $PAYLOAD | jq -r .AccessKeyId`
 export AWS_SECRET_ACCESS_KEY=`echo $PAYLOAD | jq -r .SecretAccessKey`
 export AWS_SESSION_TOKEN=`echo $PAYLOAD | jq -r .Token`


### PR DESCRIPTION
This fix addresses the fact that ECS on Fargate does not have a proper IMDSv2 endpoint, but specific task metadata endpoints and means of getting credentials.

I added a conditional test to verify if running on fargate, if so, it will try and use the task metadata endpoint. I've also customized to allow passing a role name, just to make it more clear that it matters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
